### PR TITLE
Filter file array for file selected

### DIFF
--- a/frontend/lib/useForm.js
+++ b/frontend/lib/useForm.js
@@ -10,6 +10,12 @@ export default function useForm(initial = {}) {
     }
     if (type === 'file') {
       [value] = e.target.files;
+      if (!value) {
+				null;
+			}
+			if (value) {
+				value = value[0];
+			}
     }
     setInputs({
       ...inputs,


### PR DESCRIPTION
The file type conditional in the definition of useForm() was returning an array for value instead of the file indexed at the beginning of that array. Wasn't sure if you had future plans for uploading multiple photos, but this fixes the error considering just one photo is uploaded.